### PR TITLE
Refactor to escape runtime exception

### DIFF
--- a/TacacsPlusCore/Authentication/MsChapV1.cs
+++ b/TacacsPlusCore/Authentication/MsChapV1.cs
@@ -33,10 +33,11 @@ namespace Petrsnd.TacacsPlusCore.Authentication
             var challenge = new byte[8];
             Rng.GetBytes(challenge, 0, 8);
 
-            // RFC 2433 6 states that the LAN MAnager compatible challenge has been deprecated
+            // RFC 2433 6 states that the LAN Manager compatible challenge has been deprecated
             // and should not be sent.  Instead this should be zero-filled.
-            var lmChallengeResponse = GetLmChallengeResponse(challenge, password);
-            Buffer.BlockCopy(Enumerable.Repeat((byte)0x00, 24).ToArray(), 0, lmChallengeResponse, 0, 24);
+            // var lmChallengeResponse = GetLmChallengeResponse(challenge, password);
+            // Buffer.BlockCopy(Enumerable.Repeat((byte)0x00, 24).ToArray(), 0, lmChallengeResponse, 0, 24);
+            var lmChallengeResponse = GetLmChallengeResponse();
             // RFC 2433 6, also see A.5
             var ntChallengeResponse = GetNtChallengeResponse(challenge, password);
 
@@ -68,33 +69,39 @@ namespace Petrsnd.TacacsPlusCore.Authentication
 
             return authenticationData;
         }
-
-        public static byte[] GetLmChallengeResponse(byte[] challenge, SecureString password)
+        
+        public static byte[] GetLmChallengeResponse()
         {
-            var lmPasswordHash = GetLmPasswordHash(password);
-            var key = new byte[21];
-            Buffer.BlockCopy(lmPasswordHash, 0, key, 0, 16);
-            Buffer.BlockCopy(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00 }, 0, key, 16, 5);
-            var input = new byte[24];
-            for (var i = 0; i < 3; i++)
-                Buffer.BlockCopy(challenge, 0, input, i * 8, 8);
-            return DesHash.ComputeHash(key, input);
+            // Note that use of the LAN Manager compatible challenge response has been deprecated; peers SHOULD NOT generate it, and the sub-field SHOULD be zero-filled. See RFC 2433 6.Response Packet
+            return Enumerable.Repeat((byte)0x00, 24).ToArray();
         }
 
-        public static byte[] GetLmPasswordHash(SecureString password)
-        {
-            var passwordBuf = GetLmPasswordBuffer(password);
-            var input = Encoding.ASCII.GetBytes("KGS!@#$%KGS!@#$%");
-            return DesHash.ComputeHash(passwordBuf, input);
-        }
+        // public static byte[] GetLmChallengeResponse(byte[] challenge, SecureString password)
+        // {
+        //     var lmPasswordHash = GetLmPasswordHash(password);
+        //     var key = new byte[21];
+        //     Buffer.BlockCopy(lmPasswordHash, 0, key, 0, 16);
+        //     Buffer.BlockCopy(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00 }, 0, key, 16, 5);
+        //     var input = new byte[24];
+        //     for (var i = 0; i < 3; i++)
+        //         Buffer.BlockCopy(challenge, 0, input, i * 8, 8);
+        //     return DesHash.ComputeHash(key, input);
+        // }
 
-        public static byte[] GetLmPasswordBuffer(SecureString password)
-        {
-            var passwordArray = Encoding.ASCII.GetBytes(password.ToInsecureString().ToUpper()).ToList();
-            for (var i = passwordArray.Count; i < 14; i++)
-                passwordArray.Add(0x00);
-            return passwordArray.Take(14).ToArray();
-        }
+        // public static byte[] GetLmPasswordHash(SecureString password)
+        // {
+        //     var passwordBuf = GetLmPasswordBuffer(password);
+        //     var input = Encoding.ASCII.GetBytes("KGS!@#$%KGS!@#$%");
+        //     return DesHash.ComputeHash(passwordBuf, input);
+        // }
+
+        // public static byte[] GetLmPasswordBuffer(SecureString password)
+        // {
+        //     var passwordArray = Encoding.ASCII.GetBytes(password.ToInsecureString().ToUpper()).ToList();
+        //     for (var i = passwordArray.Count; i < 14; i++)
+        //         passwordArray.Add(0x00);
+        //     return passwordArray.Take(14).ToArray();
+        // }
 
         public static byte[] GetNtChallengeResponse(byte[] challenge, SecureString password)
         {


### PR DESCRIPTION
Hello @petrsnd! 
I have a persistent error on Runtime execution for the method:
public static byte[] GetLmPasswordHash(SecureString password) -> 
public static byte[] ComputeHash(byte[] key, byte[] input) ->
Code falls for second pass of cycle on line: 
des.Key = Convert7BitKey(key.Skip(i * 7).Take(7).ToArray());

--------------------------------------------

System.Security.Cryptography.CryptographicException
  HResult=0x80131501
  Message=Specified key is a known weak key for 'DES' and cannot be used.
  Source=System.Security.Cryptography

  StackTrace:
   at System.Security.Cryptography.DES.set_Key(Byte[] value)
   at Petrsnd.TacacsPlusCore.Utils.DesHash.ComputeHash(Byte[] key, Byte[] input) in .\TacacsPlusCore\TacacsPlusCore\Utils\DesHash.cs:line 52
   at Petrsnd.TacacsPlusCore.Authentication.MsChapV1.GetLmPasswordHash(SecureString password) in .\TacacsPlusCore\TacacsPlusCore\Authentication\MsChapV1.cs:line 88
   at Petrsnd.TacacsPlusCore.Authentication.MsChapV1.GetLmChallengeResponse(Byte[] challenge, SecureString password) in .\TacacsPlusCore\TacacsPlusCore\Authentication\MsChapV1.cs:line 74
   at Petrsnd.TacacsPlusCore.Authentication.MsChapV1.GetAuthenticationData(TacacsAuthenticationService service, String user, SecureString password) in .\TacacsPlusCore\TacacsPlusCore\Authentication\MsChapV1.cs:line 38
   at Petrsnd.TacacsPlusCore.TacacsPlusProtocol.GetAuthenticationPacket(TacacsAuthenticationType type, TacacsAuthenticationService service, String user, SecureString password, SecureString sharedSecret) in .\TacacsPlusCore\TacacsPlusCore\TacacsPlusProtocol.cs:line 47
   at Petrsnd.TacacsPlusCore.TacacsPlusClient.Authenticate(TacacsAuthenticationType type, TacacsAuthenticationService service, String user, SecureString password) in .\TacacsPlusCore\TacacsPlusCore\TacacsPlusClient.cs:line 53
   at TacacsPlus.TacacsPlusClient.Authenticate(Int32 authenticationType, String login, String password) in .\TacacsPlusCore\TacacsPlus\TacacsPlusClient.cs:line 32
   at Program.<Main>$(String[] args) in .\TacacsPlusCore\TacacsPlusConsole\Program.cs:line 28

  This exception was originally thrown at this call stack:
    System.Security.Cryptography.DES.Key.set(byte[])
    Petrsnd.TacacsPlusCore.Utils.DesHash.ComputeHash(byte[], byte[]) in DesHash.cs
    Petrsnd.TacacsPlusCore.Authentication.MsChapV1.GetLmPasswordHash(System.Security.SecureString) in MsChapV1.cs
    Petrsnd.TacacsPlusCore.Authentication.MsChapV1.GetLmChallengeResponse(byte[], System.Security.SecureString) in MsChapV1.cs
    Petrsnd.TacacsPlusCore.Authentication.MsChapV1.GetAuthenticationData(Petrsnd.TacacsPlusCore.TacacsAuthenticationService, string, System.Security.SecureString) in MsChapV1.cs
    Petrsnd.TacacsPlusCore.TacacsPlusProtocol.GetAuthenticationPacket(Petrsnd.TacacsPlusCore.TacacsAuthenticationType, Petrsnd.TacacsPlusCore.TacacsAuthenticationService, string, System.Security.SecureString, System.Security.SecureString) in TacacsPlusProtocol.cs
    Petrsnd.TacacsPlusCore.TacacsPlusClient.Authenticate(Petrsnd.TacacsPlusCore.TacacsAuthenticationType, Petrsnd.TacacsPlusCore.TacacsAuthenticationService, string, System.Security.SecureString) in TacacsPlusClient.cs
    TacacsPlus.TacacsPlusClient.Authenticate(int, string, string) in TacacsPlusClient.cs
    Program.<Main>$(string[]) in Program.cs
    
 --------------------------------------
 
 I propose to completely eliminate the calculations of GetLmPasswordHash, replacing it with the default value that is required in the end. What do you think?
 
 Thanks for your dedication to keeping your awesome package up to date!